### PR TITLE
Support for using shadergarden through standard input and piping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1500,6 +1500,7 @@ dependencies = [
  "include_dir",
  "lexpr",
  "notify",
+ "signal-hook",
  "structopt",
 ]
 
@@ -1518,6 +1519,25 @@ name = "shlex"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
+
+[[package]]
+name = "signal-hook"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a253b5e89e2698464fc26b545c9edceb338e18a89effeeecfea192c3025be29d"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "smallvec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,4 @@ lexpr = "0.2.6"
 include_dir = "0.6"
 ffmpeg-next = { version = "4.4", optional = true }
 structopt = "0.3"
+signal-hook = "0.3.14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,4 +22,6 @@ lexpr = "0.2.6"
 include_dir = "0.6"
 ffmpeg-next = { version = "4.4", optional = true }
 structopt = "0.3"
+
+[target.'cfg(unix)'.dependencies]
 signal-hook = "0.3.14"

--- a/src/lisp/mod.rs
+++ b/src/lisp/mod.rs
@@ -231,6 +231,16 @@ fn node(
             )?;
             Ok(Val::Node(node_id))
         },
+        "shader-inline" => {
+            let (src, width, height, inputs) = shader(graph, env, iter)?;
+            let node_id = graph.add_shader(
+                &src,
+                inputs,
+                width as u32,
+                height as u32,
+            )?;
+            Ok(Val::Node(node_id))
+        },
         "shader-param" => {
             // get the shader we'll be running the transformations
             // against
@@ -256,6 +266,16 @@ fn node(
             let (name, width, height, inputs) = shader(graph, env, iter)?;
             let node_id = graph.add_rec_shader(
                 env.shader(&name)?,
+                inputs,
+                width as u32,
+                height as u32,
+            )?;
+            Ok(Val::Node(node_id))
+        },
+        "shader-rec-inline" => {
+            let (src, width, height, inputs) = shader(graph, env, iter)?;
+            let node_id = graph.add_rec_shader(
+                &src,
                 inputs,
                 width as u32,
                 height as u32,

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,11 +21,10 @@ use glium::{
     Surface,
 };
 use shadergarden::{
-    lisp,
-    map,
     png,
     reload,
     util,
+    reload::watcher::ShaderGraphWatcher
 };
 use structopt::{
     clap::AppSettings,
@@ -166,16 +165,7 @@ fn render(render: Render) {
     );
 
     // set up hot code reloading
-    let shader_dir = reload::ShaderDir::new_from_dir(args.project, lisp_config)
-        .expect("Could not load initial shader directory");
-    let mut graph =
-        lisp::graph_from_sexp(display.get_context(), shader_dir, map! {})
-            .map_err(|e| {
-                eprintln!("[fatal] Could not build initial graph:");
-                eprintln!("{}", e);
-                panic!();
-            })
-            .unwrap();
+    let mut graph = ShaderGraphWatcher::build_initial(display.get_context(), &args.project, &lisp_config).unwrap();
 
     eprintln!("[info] Built initial graph");
 

--- a/src/reload/shader_dir.rs
+++ b/src/reload/shader_dir.rs
@@ -2,6 +2,7 @@ use std::{
     collections::BTreeMap,
     ffi::OsStr,
     fs,
+    io,
     path::Path,
 };
 
@@ -72,12 +73,19 @@ impl ShaderDir {
     where
         T: AsRef<Path>,
     {
-        let lisp = fs::read_to_string(&config).map_err(|_| {
-            format!(
-                "Could not read `{}` in shader directory",
-                config.as_ref().to_str().unwrap()
-            )
-        })?;
+        let lisp = 
+            if config.as_ref().to_str().unwrap() == "-" {
+                io::read_to_string(io::stdin()).map_err(|_| {
+                    "Could not read config in stdin"
+                })?
+            } else {
+                fs::read_to_string(&config).map_err(|_| {
+                    format!(
+                        "Could not read `{}` in shader directory",
+                        config.as_ref().to_str().unwrap()
+                    )
+                })?
+            };
 
         let mut shaders = BTreeMap::new();
         let files = fs::read_dir(path)

--- a/src/reload/shader_dir.rs
+++ b/src/reload/shader_dir.rs
@@ -3,7 +3,6 @@ use std::{
     ffi::OsStr,
     fs,
     path::Path,
-
 };
 
 use include_dir::{
@@ -69,26 +68,12 @@ impl ShaderDir {
     }
 
     /// Creates a new `ShaderDir` from a directory.
-    pub fn new_from_dir<T>(path: T, config: T) -> Result<ShaderDir, String>
+    pub fn new_from_dir<T>(path: T, get_lisp : impl Fn() -> Result<String, String>) -> Result<ShaderDir, String>
     where
         T: AsRef<Path>,
     {
-        let config_str = config.as_ref().to_str().unwrap();
 
-        let lisp = //custom stdin s-expression consuming function here 
-            if config_str == "-" {
-                // read_stdin_config().map_err(|s| {
-                //     format!("Could not read config from stdin: {}", s)
-                // })?
-                return Err("Debug".to_string());
-            } else {
-                fs::read_to_string(&config).map_err(|_| {
-                    format!(
-                        "Could not read `{}` in shader directory",
-                        config_str
-                    )
-                })?
-            };
+        let lisp = get_lisp()?;
 
         let mut shaders = BTreeMap::new();
         let files = fs::read_dir(path)

--- a/src/reload/watcher.rs
+++ b/src/reload/watcher.rs
@@ -92,7 +92,7 @@ impl ShaderGraphWatcher {
                     thread::spawn(move || {
                         for sig in s.forever() {
                             changed.store(true, Ordering::SeqCst);
-                            println!("Received signal {:?}", sig);
+                            println!("[info] Received signal {:?}", sig);
                         }
                     });
                 }

--- a/src/reload/watcher.rs
+++ b/src/reload/watcher.rs
@@ -268,9 +268,16 @@ fn read_stdin_config() -> Result<String, String> {
         loop {
             let bytes_read = handle.read_until(b')', &mut byte_vec);
             match bytes_read {
-                Ok(0) => return Err("Nothing read error (STDIN closed?)".to_string()),
+                Ok(0) => {
+                    return Err("No bytes were read (STDIN closed?)".to_string());
+                },
+                Ok(_) if *byte_vec.last().unwrap() != b')' => {
+                    return Err("Last byte read not ')' (STDIN closed?)".to_string());
+                },
                 Ok(read) => {
                     //count the number of opening parenthesis in read bytes
+                    // println!("Number of bytes read: {}", read);
+                    // println!("Last byte read: {}", *(byte_vec.last().unwrap()) as char);
                     let len = byte_vec.len();
                     for i in len-read..len {
                         if b'(' == byte_vec[i] {
@@ -278,7 +285,9 @@ fn read_stdin_config() -> Result<String, String> {
                         }
                     };                 
                 },
-                Err(err) => return Err(format!("Reading STDIN error: {}", err)),
+                Err(err) => {
+                    return Err(format!("Reading STDIN error: {}", err));
+                },
             };
 
             //subtract 1 since we reached a closing parenthesis


### PR DESCRIPTION
READ NEXT COMMENT FOR INFORMATION ABOUT THIS PR

One last consideration: have a separate thread reading from stdin in a blocking manner. Whenever a full config is read from stdin, set a string variable, set the reload bool, and have a subprocedure in the reload procedure read said string variable to pass to the graph creation function. This is different from the current implementation which reads from stdin in the reload procedure directly. There is no way to set the reload bool when stdin is filled automatically. The current code works when manually reloading with SIGUSR1 though! This should be the last edit before this can be merged to (my fork's) master.